### PR TITLE
Enhance 'Node' and add 'Nodes' endpoints

### DIFF
--- a/pkg/assembler/backends/ent/backend/neighbors.go
+++ b/pkg/assembler/backends/ent/backend/neighbors.go
@@ -6,6 +6,7 @@ import (
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/packagenamespace"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/packagetype"
 	"github.com/guacsec/guac/pkg/assembler/backends/ent/packageversion"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent/sourcetype"
 	"log"
 	"strconv"
 
@@ -81,6 +82,27 @@ func (b *EntBackend) Node(ctx context.Context, node string) (model.Node, error) 
 			return nil, err
 		}
 		return toModelPackage(pt), nil
+	case *ent.SourceType:
+		s, err := b.client.SourceType.Query().
+			Where(sourcetype.ID(v.ID)).
+			WithNamespaces(func(q *ent.SourceNamespaceQuery) {
+				q.WithNames()
+			}).
+			Only(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return toModelSource(s), nil
+	case *ent.Builder:
+		return toModelBuilder(v), nil
+	case *ent.SecurityAdvisory:
+		if v.OsvID != nil {
+			return toModelOSV(v), nil
+		} else if v.CveID != nil {
+			return toModelCVE(v), nil
+		} else if v.GhsaID != nil {
+			return toModelGHSA(v), nil
+		}
 	default:
 		log.Printf("Unknown node type: %T", v)
 	}

--- a/pkg/assembler/backends/ent/backend/neighbors.go
+++ b/pkg/assembler/backends/ent/backend/neighbors.go
@@ -2,6 +2,10 @@ package backend
 
 import (
 	"context"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent/packagename"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent/packagenamespace"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent/packagetype"
+	"github.com/guacsec/guac/pkg/assembler/backends/ent/packageversion"
 	"log"
 	"strconv"
 
@@ -28,14 +32,70 @@ func (b *EntBackend) Node(ctx context.Context, node string) (model.Node, error) 
 	case *ent.Artifact:
 		return toModelArtifact(v), nil
 	case *ent.PackageVersion:
-		return toModelPackage(backReferencePackageVersion(v)), nil
+		pv, err := b.client.PackageVersion.Query().
+			Where(packageversion.ID(v.ID)).
+			WithName(func(q *ent.PackageNameQuery) {
+				q.WithNamespace(func(q *ent.PackageNamespaceQuery) {
+					q.WithPackage()
+				})
+			}).
+			Only(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return toModelPackage(backReferencePackageVersion(pv)), nil
 	case *ent.PackageName:
-		return toModelPackage(backReferencePackageName(v)), nil
+		pn, err := b.client.PackageName.Query().
+			Where(packagename.ID(v.ID)).
+			WithNamespace(func(q *ent.PackageNamespaceQuery) {
+				q.WithPackage()
+			}).
+			WithVersions().
+			Only(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return toModelPackage(backReferencePackageName(pn)), nil
+	case *ent.PackageNamespace:
+		pns, err := b.client.PackageNamespace.Query().
+			Where(packagenamespace.ID(v.ID)).
+			WithPackage().
+			WithNames(func(q *ent.PackageNameQuery) {
+				q.WithVersions()
+			}).
+			Only(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return toModelPackage(backReferencePackageNamespace(pns)), nil
 	case *ent.PackageType:
-		return toModelPackage(v), nil
+		pt, err := b.client.PackageType.Query().
+			Where(packagetype.ID(v.ID)).
+			WithNamespaces(func(q *ent.PackageNamespaceQuery) {
+				q.WithNames(func(q *ent.PackageNameQuery) {
+					q.WithVersions()
+				})
+			}).
+			Only(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return toModelPackage(pt), nil
 	default:
 		log.Printf("Unknown node type: %T", v)
 	}
 
 	return nil, nil
+}
+
+func (b *EntBackend) Nodes(ctx context.Context, nodes []string) ([]model.Node, error) {
+	rv := make([]model.Node, 0, len(nodes))
+	for _, id := range nodes {
+		n, err := b.Node(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		rv = append(rv, n)
+	}
+	return rv, nil
 }

--- a/pkg/assembler/backends/ent/backend/neighbors.go
+++ b/pkg/assembler/backends/ent/backend/neighbors.go
@@ -89,14 +89,8 @@ func (b *EntBackend) Node(ctx context.Context, node string) (model.Node, error) 
 		return toModelSource(s), nil
 	case *ent.Builder:
 		return toModelBuilder(v), nil
-	case *ent.SecurityAdvisory:
-		if v.OsvID != nil {
-			return toModelOSV(v), nil
-		} else if v.CveID != nil {
-			return toModelCVE(v), nil
-		} else if v.GhsaID != nil {
-			return toModelGHSA(v), nil
-		}
+	case *ent.VulnerabilityType:
+		return toModelVulnerability(v), nil
 	default:
 		log.Printf("Unknown node type: %T", v)
 	}

--- a/pkg/assembler/backends/ent/backend/neighbors.go
+++ b/pkg/assembler/backends/ent/backend/neighbors.go
@@ -72,11 +72,7 @@ func (b *EntBackend) Node(ctx context.Context, node string) (model.Node, error) 
 	case *ent.PackageType:
 		pt, err := b.client.PackageType.Query().
 			Where(packagetype.ID(v.ID)).
-			WithNamespaces(func(q *ent.PackageNamespaceQuery) {
-				q.WithNames(func(q *ent.PackageNameQuery) {
-					q.WithVersions()
-				})
-			}).
+			WithNamespaces().
 			Only(ctx)
 		if err != nil {
 			return nil, err
@@ -85,9 +81,7 @@ func (b *EntBackend) Node(ctx context.Context, node string) (model.Node, error) 
 	case *ent.SourceType:
 		s, err := b.client.SourceType.Query().
 			Where(sourcetype.ID(v.ID)).
-			WithNamespaces(func(q *ent.SourceNamespaceQuery) {
-				q.WithNames()
-			}).
+			WithNamespaces().
 			Only(ctx)
 		if err != nil {
 			return nil, err

--- a/pkg/assembler/backends/ent/backend/neighbors_test.go
+++ b/pkg/assembler/backends/ent/backend/neighbors_test.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/guacsec/guac/pkg/assembler/backends"
+	"github.com/guacsec/guac/pkg/assembler/graphql/model"
 )
 
 func (s *Suite) TestNode() {
@@ -12,14 +13,14 @@ func (s *Suite) TestNode() {
 	v, err := be.IngestArtifact(s.Ctx, a1)
 	check(s, be, v.ID, err, a1out)
 
-	p, err := be.IngestPackage(s.Ctx, *p1)
-	check(s, be, p.ID, err, p1out)
-	check(s, be, p.Namespaces[0].ID, err, p1out)
-	check(s, be, p.Namespaces[0].Names[0].ID, err, p1out)
-	check(s, be, p.Namespaces[0].Names[0].Versions[0].ID, err, p1out)
+	p, err := be.IngestPackage(s.Ctx, *p4)
+	check(s, be, p.ID, err, p4outNamespace)
+	check(s, be, p.Namespaces[0].ID, err, p4out)
+	check(s, be, p.Namespaces[0].Names[0].ID, err, p4out)
+	check(s, be, p.Namespaces[0].Names[0].Versions[0].ID, err, p4out)
 
 	sc, err := be.IngestSource(s.Ctx, *s1)
-	check(s, be, sc.ID, err, s1out)
+	check(s, be, sc.ID, err, s1outNamespace)
 
 	bu, err := be.IngestBuilder(s.Ctx, b1)
 	check(s, be, bu.ID, err, b1out)
@@ -34,6 +35,81 @@ func (s *Suite) TestNode() {
 	check(s, be, g.ID, err, g1out)
 }
 
+func (s *Suite) TestNodeNew() {
+	ctx := s.Ctx
+	tests := []struct {
+		Name     string
+		InArt    []*model.ArtifactInputSpec
+		InPkg    []*model.PkgInputSpec
+		InSrc    []*model.SourceInputSpec
+		Expected []interface{}
+		Only     bool
+	}{
+		{
+			Name:  "Ingest Artifact",
+			InArt: []*model.ArtifactInputSpec{a1},
+			InPkg: []*model.PkgInputSpec{p4},
+			InSrc: []*model.SourceInputSpec{s1},
+			Expected: []interface{}{
+				a1out,
+				p4outNamespace,
+				s1outNamespace,
+			},
+		},
+	}
+	hasOnly := false
+	for _, t := range tests {
+		if t.Only {
+			hasOnly = true
+			break
+		}
+	}
+
+	for _, test := range tests {
+		if hasOnly && !test.Only {
+			continue
+		}
+
+		s.Run(test.Name, func() {
+			b, err := GetBackend(s.Client)
+			s.Require().NoError(err, "Could not instantiate testing backend")
+
+			ids := make([]string, 0, len(test.Expected))
+			for _, inA := range test.InArt {
+				if a, err := b.IngestArtifact(ctx, inA); err != nil {
+					s.T().Fatalf("Could not ingest artifact: %v", err)
+				} else {
+					ids = append(ids, a.ID)
+				}
+			}
+
+			for _, inP := range test.InPkg {
+				if p, err := b.IngestPackage(ctx, *inP); err != nil {
+					s.T().Fatalf("Could not ingest package: %v", err)
+				} else {
+					ids = append(ids, p.ID)
+				}
+			}
+
+			for _, inSrc := range test.InSrc {
+				if src, err := b.IngestSource(ctx, *inSrc); err != nil {
+					s.T().Fatalf("Could not ingest source: %v", err)
+				} else {
+					ids = append(ids, src.ID)
+				}
+			}
+
+			for i, id := range ids {
+				n, err := b.Node(s.Ctx, id)
+				s.Require().NoError(err)
+				if diff := cmp.Diff(test.Expected[i], n, ignoreID, ignoreEmptySlices); diff != "" {
+					s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
 func (s *Suite) TestNodes() {
 	be, err := GetBackend(s.Client)
 	s.Require().NoError(err)
@@ -41,7 +117,7 @@ func (s *Suite) TestNodes() {
 	v, err := be.IngestArtifact(s.Ctx, a1)
 	s.Require().NoError(err)
 
-	p, err := be.IngestPackage(s.Ctx, *p1)
+	p, err := be.IngestPackage(s.Ctx, *p4)
 	s.Require().NoError(err)
 
 	nodes, err := be.Nodes(s.Ctx, []string{v.ID, p.ID, p.Namespaces[0].Names[0].Versions[0].ID})
@@ -49,10 +125,10 @@ func (s *Suite) TestNodes() {
 	if diff := cmp.Diff(a1out, nodes[0], ignoreID, ignoreEmptySlices); diff != "" {
 		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
 	}
-	if diff := cmp.Diff(p1out, nodes[1], ignoreID, ignoreEmptySlices); diff != "" {
+	if diff := cmp.Diff(p4outNamespace, nodes[1], ignoreID, ignoreEmptySlices); diff != "" {
 		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
 	}
-	if diff := cmp.Diff(p1out, nodes[2], ignoreID, ignoreEmptySlices); diff != "" {
+	if diff := cmp.Diff(p4out, nodes[2], ignoreID, ignoreEmptySlices); diff != "" {
 		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/assembler/backends/ent/backend/neighbors_test.go
+++ b/pkg/assembler/backends/ent/backend/neighbors_test.go
@@ -1,10 +1,10 @@
 package backend
 
-import "github.com/google/go-cmp/cmp"
+import (
+	"github.com/google/go-cmp/cmp"
+)
 
 func (s *Suite) TestNode() {
-	s.T().Skip()
-
 	be, err := GetBackend(s.Client)
 	s.Require().NoError(err)
 
@@ -25,6 +25,39 @@ func (s *Suite) TestNode() {
 	s.Require().NoError(err)
 
 	if diff := cmp.Diff(p1out, n, ignoreID, ignoreEmptySlices); diff != "" {
+		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+	}
+
+	n, err = be.Node(s.Ctx, p.Namespaces[0].ID)
+	s.Require().NoError(err)
+
+	if diff := cmp.Diff(p1out, n, ignoreID, ignoreEmptySlices); diff != "" {
+		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+	}
+
+	n, err = be.Node(s.Ctx, p.Namespaces[0].Names[0].ID)
+	s.Require().NoError(err)
+
+	if diff := cmp.Diff(p1out, n, ignoreID, ignoreEmptySlices); diff != "" {
+		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+	}
+
+	n, err = be.Node(s.Ctx, p.Namespaces[0].Names[0].Versions[0].ID)
+	s.Require().NoError(err)
+
+	if diff := cmp.Diff(p1out, n, ignoreID, ignoreEmptySlices); diff != "" {
+		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+	}
+
+	nodes, err := be.Nodes(s.Ctx, []string{v.ID, p.ID, p.Namespaces[0].Names[0].Versions[0].ID})
+	s.Require().NoError(err)
+	if diff := cmp.Diff(a1out, nodes[0], ignoreID, ignoreEmptySlices); diff != "" {
+		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(p1out, nodes[1], ignoreID, ignoreEmptySlices); diff != "" {
+		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(p1out, nodes[2], ignoreID, ignoreEmptySlices); diff != "" {
 		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/assembler/backends/ent/backend/neighbors_test.go
+++ b/pkg/assembler/backends/ent/backend/neighbors_test.go
@@ -7,41 +7,13 @@ import (
 )
 
 func (s *Suite) TestNode() {
-	be, err := GetBackend(s.Client)
-	s.Require().NoError(err)
-
-	v, err := be.IngestArtifact(s.Ctx, a1)
-	check(s, be, v.ID, err, a1out)
-
-	p, err := be.IngestPackage(s.Ctx, *p4)
-	check(s, be, p.ID, err, p4outNamespace)
-	check(s, be, p.Namespaces[0].ID, err, p4out)
-	check(s, be, p.Namespaces[0].Names[0].ID, err, p4out)
-	check(s, be, p.Namespaces[0].Names[0].Versions[0].ID, err, p4out)
-
-	sc, err := be.IngestSource(s.Ctx, *s1)
-	check(s, be, sc.ID, err, s1outNamespace)
-
-	bu, err := be.IngestBuilder(s.Ctx, b1)
-	check(s, be, bu.ID, err, b1out)
-
-	osv, err := be.IngestOsv(s.Ctx, o1)
-	check(s, be, osv.ID, err, o1out)
-
-	c, err := be.IngestCve(s.Ctx, c1)
-	check(s, be, c.ID, err, c1out)
-
-	g, err := be.IngestGhsa(s.Ctx, g1)
-	check(s, be, g.ID, err, g1out)
-}
-
-func (s *Suite) TestNodeNew() {
 	ctx := s.Ctx
 	tests := []struct {
 		Name     string
 		InArt    []*model.ArtifactInputSpec
 		InPkg    []*model.PkgInputSpec
 		InSrc    []*model.SourceInputSpec
+		InBld    []*model.BuilderInputSpec
 		Expected []interface{}
 		Only     bool
 	}{
@@ -50,10 +22,12 @@ func (s *Suite) TestNodeNew() {
 			InArt: []*model.ArtifactInputSpec{a1},
 			InPkg: []*model.PkgInputSpec{p4},
 			InSrc: []*model.SourceInputSpec{s1},
+			InBld: []*model.BuilderInputSpec{b1},
 			Expected: []interface{}{
 				a1out,
 				p4outNamespace,
 				s1outNamespace,
+				b1out,
 			},
 		},
 	}
@@ -96,6 +70,14 @@ func (s *Suite) TestNodeNew() {
 					s.T().Fatalf("Could not ingest source: %v", err)
 				} else {
 					ids = append(ids, src.ID)
+				}
+			}
+
+			for _, inBLD := range test.InBld {
+				if bld, err := b.IngestBuilder(ctx, inBLD); err != nil {
+					s.T().Fatalf("Could not ingest builder: %v", err)
+				} else {
+					ids = append(ids, bld.ID)
 				}
 			}
 

--- a/pkg/assembler/backends/ent/backend/neighbors_test.go
+++ b/pkg/assembler/backends/ent/backend/neighbors_test.go
@@ -2,9 +2,39 @@ package backend
 
 import (
 	"github.com/google/go-cmp/cmp"
+	"github.com/guacsec/guac/pkg/assembler/backends"
 )
 
 func (s *Suite) TestNode() {
+	be, err := GetBackend(s.Client)
+	s.Require().NoError(err)
+
+	v, err := be.IngestArtifact(s.Ctx, a1)
+	check(s, be, v.ID, err, a1out)
+
+	p, err := be.IngestPackage(s.Ctx, *p1)
+	check(s, be, p.ID, err, p1out)
+	check(s, be, p.Namespaces[0].ID, err, p1out)
+	check(s, be, p.Namespaces[0].Names[0].ID, err, p1out)
+	check(s, be, p.Namespaces[0].Names[0].Versions[0].ID, err, p1out)
+
+	sc, err := be.IngestSource(s.Ctx, *s1)
+	check(s, be, sc.ID, err, s1out)
+
+	bu, err := be.IngestBuilder(s.Ctx, b1)
+	check(s, be, bu.ID, err, b1out)
+
+	osv, err := be.IngestOsv(s.Ctx, o1)
+	check(s, be, osv.ID, err, o1out)
+
+	c, err := be.IngestCve(s.Ctx, c1)
+	check(s, be, c.ID, err, c1out)
+
+	g, err := be.IngestGhsa(s.Ctx, g1)
+	check(s, be, g.ID, err, g1out)
+}
+
+func (s *Suite) TestNodes() {
 	be, err := GetBackend(s.Client)
 	s.Require().NoError(err)
 
@@ -13,41 +43,6 @@ func (s *Suite) TestNode() {
 
 	p, err := be.IngestPackage(s.Ctx, *p1)
 	s.Require().NoError(err)
-
-	n, err := be.Node(s.Ctx, v.ID)
-	s.Require().NoError(err)
-
-	if diff := cmp.Diff(a1out, n, ignoreID, ignoreEmptySlices); diff != "" {
-		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
-	}
-
-	n, err = be.Node(s.Ctx, p.ID)
-	s.Require().NoError(err)
-
-	if diff := cmp.Diff(p1out, n, ignoreID, ignoreEmptySlices); diff != "" {
-		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
-	}
-
-	n, err = be.Node(s.Ctx, p.Namespaces[0].ID)
-	s.Require().NoError(err)
-
-	if diff := cmp.Diff(p1out, n, ignoreID, ignoreEmptySlices); diff != "" {
-		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
-	}
-
-	n, err = be.Node(s.Ctx, p.Namespaces[0].Names[0].ID)
-	s.Require().NoError(err)
-
-	if diff := cmp.Diff(p1out, n, ignoreID, ignoreEmptySlices); diff != "" {
-		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
-	}
-
-	n, err = be.Node(s.Ctx, p.Namespaces[0].Names[0].Versions[0].ID)
-	s.Require().NoError(err)
-
-	if diff := cmp.Diff(p1out, n, ignoreID, ignoreEmptySlices); diff != "" {
-		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
-	}
 
 	nodes, err := be.Nodes(s.Ctx, []string{v.ID, p.ID, p.Namespaces[0].Names[0].Versions[0].ID})
 	s.Require().NoError(err)
@@ -58,6 +53,15 @@ func (s *Suite) TestNode() {
 		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(p1out, nodes[2], ignoreID, ignoreEmptySlices); diff != "" {
+		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
+	}
+}
+
+func check(s *Suite, be backends.Backend, id string, err error, expected interface{}) {
+	s.Require().NoError(err)
+	n, err := be.Node(s.Ctx, id)
+	s.Require().NoError(err)
+	if diff := cmp.Diff(expected, n, ignoreID, ignoreEmptySlices); diff != "" {
 		s.T().Errorf("Unexpected results. (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/assembler/backends/ent/backend/occurrence_test.go
+++ b/pkg/assembler/backends/ent/backend/occurrence_test.go
@@ -45,6 +45,7 @@ var p1 = &model.PkgInputSpec{
 var p1out = &model.Package{
 	Type: "pypi",
 	Namespaces: []*model.PackageNamespace{{
+		Namespace: "aaa",
 		Names: []*model.PackageName{{
 			Name: "tensorflow",
 			Versions: []*model.PackageVersion{{
@@ -141,6 +142,13 @@ var p4outName = &model.Package{
 	}},
 }
 
+var p4outNamespace = &model.Package{
+	Type: "conan",
+	Namespaces: []*model.PackageNamespace{{
+		Namespace: "openssl.org",
+	}},
+}
+
 var s1 = &model.SourceInputSpec{
 	Type:      "git",
 	Namespace: "github.com/jeff",
@@ -155,6 +163,13 @@ var s1out = &model.Source{
 			Tag:    ptrfrom.String(""),
 			Commit: ptrfrom.String(""),
 		}},
+	}},
+}
+
+var s1outNamespace = &model.Source{
+	Type: "git",
+	Namespaces: []*model.SourceNamespace{{
+		Namespace: "github.com/jeff",
 	}},
 }
 

--- a/pkg/assembler/backends/ent/backend/package.go
+++ b/pkg/assembler/backends/ent/backend/package.go
@@ -391,6 +391,15 @@ func backReferencePackageName(pn *ent.PackageName) *ent.PackageType {
 	return nil
 }
 
+func backReferencePackageNamespace(pns *ent.PackageNamespace) *ent.PackageType {
+	if pns.Edges.Package != nil {
+		pt := pns.Edges.Package
+		pt.Edges.Namespaces = []*ent.PackageNamespace{pns}
+		return pt
+	}
+	return nil
+}
+
 // Each "noun" node will need a "get" for any time an ingest happens on a
 // "verb" node that points to it. All but Package and Source are simple. For
 // Package, some verbs link to Name and some to Version, or some both. For


### PR DESCRIPTION
- Enhanced the `Nodes` endpoint adding queries in order to have the different `backReferencePackage*` methods to work
- added `backReferencePackageNamespace` method
- added the `Nodes` endpoint implementation
- added tests for them all with coverage for `neighbors.go` ~75%

If you agree the approach of running queries within the `switch v := record.(type)` blocks is fine in order to retrieve all the information to build the responses, then I can implement the management for the other resources expected to have in response for a `Node` query

Update 26/07 (f0b9362)

- Added SourceType, Builder, SecurityAdvisory entities management in `neighbors.go` with tests (coverage ~79%)
- refactored test: split Node and Nodes testing and introduced `check` to apply always the same tests for Node