### PR TITLE
e2e test based changes

### DIFF
--- a/pkg/assembler/backends/ent/backend/package.go
+++ b/pkg/assembler/backends/ent/backend/package.go
@@ -34,6 +34,18 @@ func (b *EntBackend) Packages(ctx context.Context, pkgSpec *model.PkgSpec) ([]*m
 
 	query.Where(
 		optionalPredicate(pkgSpec.Type, packagetype.TypeEQ),
+		packagetype.HasNamespacesWith(
+			optionalPredicate(pkgSpec.Namespace, packagenamespace.NamespaceEQ),
+			packagenamespace.HasNamesWith(
+				optionalPredicate(pkgSpec.Name, packagename.NameEQ),
+				packagename.HasVersionsWith(
+					optionalPredicate(pkgSpec.ID, IDEQ),
+					optionalPredicate(pkgSpec.Version, packageversion.VersionEqualFold),
+					packageversion.SubpathEQ(ptrWithDefault(pkgSpec.Subpath, "")),
+					packageversion.QualifiersMatch(pkgSpec.Qualifiers, ptrWithDefault(pkgSpec.MatchOnlyEmptyQualifiers, false)),
+				),
+			),
+		),
 	)
 
 	if PathContains(paths, "namespaces") || !isGQL {

--- a/pkg/assembler/backends/ent/backend/vulnerability.go
+++ b/pkg/assembler/backends/ent/backend/vulnerability.go
@@ -167,34 +167,56 @@ func getAdvisoryFromVulnerabilityInput(ctx context.Context, client *ent.Client, 
 }
 
 func (b *EntBackend) CertifyVuln(ctx context.Context, spec *model.CertifyVulnSpec) ([]*model.CertifyVuln, error) {
-	records, err := b.client.CertifyVuln.Query().
-		Where(
-			optionalPredicate(spec.ID, IDEQ),
-			optionalPredicate(spec.Collector, certifyvuln.CollectorEQ),
-			optionalPredicate(spec.Origin, certifyvuln.OriginEQ),
-			optionalPredicate(spec.DbURI, certifyvuln.DbURIEQ),
-			optionalPredicate(spec.DbVersion, certifyvuln.DbVersionEQ),
-			optionalPredicate(spec.ScannerURI, certifyvuln.ScannerURIEQ),
-			optionalPredicate(spec.TimeScanned, certifyvuln.TimeScannedEQ),
-			optionalPredicate(spec.Package, func(pkg model.PkgSpec) predicate.CertifyVuln {
-				return certifyvuln.HasPackageWith(
-					optionalPredicate(spec.ID, IDEQ),
-					optionalPredicate(pkg.Version, packageversion.VersionEQ),
-					optionalPredicate(pkg.Subpath, packageversion.SubpathEQ),
-					packageversion.QualifiersMatch(pkg.Qualifiers, ptrWithDefault(pkg.MatchOnlyEmptyQualifiers, false)),
+	predicates := []predicate.CertifyVuln{
+		optionalPredicate(spec.ID, IDEQ),
+		optionalPredicate(spec.Collector, certifyvuln.CollectorEQ),
+		optionalPredicate(spec.Origin, certifyvuln.OriginEQ),
+		optionalPredicate(spec.DbURI, certifyvuln.DbURIEQ),
+		optionalPredicate(spec.DbVersion, certifyvuln.DbVersionEQ),
+		optionalPredicate(spec.ScannerURI, certifyvuln.ScannerURIEQ),
+		optionalPredicate(spec.TimeScanned, certifyvuln.TimeScannedEQ),
+		optionalPredicate(spec.Package, func(pkg model.PkgSpec) predicate.CertifyVuln {
+			return certifyvuln.HasPackageWith(
+				optionalPredicate(spec.ID, IDEQ),
+				optionalPredicate(pkg.Version, packageversion.VersionEQ),
+				optionalPredicate(pkg.Subpath, packageversion.SubpathEQ),
+				packageversion.QualifiersMatch(pkg.Qualifiers, ptrWithDefault(pkg.MatchOnlyEmptyQualifiers, false)),
 
-					packageversion.HasNameWith(
-						optionalPredicate(pkg.Name, packagename.Name),
-						packagename.HasNamespaceWith(
-							optionalPredicate(pkg.Namespace, packagenamespace.Namespace),
-							packagenamespace.HasPackageWith(
-								optionalPredicate(pkg.Type, packagetype.Type),
-							),
+				packageversion.HasNameWith(
+					optionalPredicate(pkg.Name, packagename.Name),
+					packagename.HasNamespaceWith(
+						optionalPredicate(pkg.Namespace, packagenamespace.Namespace),
+						packagenamespace.HasPackageWith(
+							optionalPredicate(pkg.Type, packagetype.Type),
 						),
 					),
-				)
-			}),
-		).
+				),
+			)
+		}),
+	}
+
+	var vulnPreds []predicate.SecurityAdvisory
+	if spec.Vulnerability != nil {
+		if spec.Vulnerability.Cve != nil {
+			vulnPreds = append(vulnPreds, optionalPredicate(spec.Vulnerability.Cve.ID, IDEQ))
+			vulnPreds = append(vulnPreds, optionalPredicate(spec.Vulnerability.Cve.CveID, securityadvisory.CveIDEqualFold))
+			vulnPreds = append(vulnPreds, optionalPredicate(spec.Vulnerability.Cve.Year, securityadvisory.CveYearEQ))
+		}
+		if spec.Vulnerability.Osv != nil {
+			vulnPreds = append(vulnPreds, optionalPredicate(spec.Vulnerability.Osv.ID, IDEQ))
+			vulnPreds = append(vulnPreds, optionalPredicate(spec.Vulnerability.Osv.OsvID, securityadvisory.OsvIDEqualFold))
+		}
+		if spec.Vulnerability.Ghsa != nil {
+			vulnPreds = append(vulnPreds, optionalPredicate(spec.Vulnerability.Ghsa.ID, IDEQ))
+			vulnPreds = append(vulnPreds, optionalPredicate(spec.Vulnerability.Ghsa.GhsaID, securityadvisory.GhsaIDEqualFold))
+		}
+		if spec.Vulnerability.NoVuln == nil {
+			predicates = append(predicates, certifyvuln.HasVulnerabilityWith(vulnPreds...))
+		}
+	}
+
+	records, err := b.client.CertifyVuln.Query().
+		Where(predicates...).
 		WithPackage(func(q *ent.PackageVersionQuery) {
 			q.WithName(func(q *ent.PackageNameQuery) {
 				q.WithNamespace(func(q *ent.PackageNamespaceQuery) {


### PR DESCRIPTION
I've tried running https://github.com/guacsec/guac/tree/main/internal/testing/e2e/e2e/ script against guac with PostgreSQL backend (with some basic changes).
I've commented the `expectPathQ1` and `expectPathPy` tests because of `Path` endpoint being not implemented yet.

Two tests failed (i.e. `expectPkgQ3` and `expectCertifyVulnQ1`) and that's what the changes here are based upon.
Now all the e2e tests work (and also the unit tests still work fine).
